### PR TITLE
QR code journey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ app.post('/tink/payment', tinkPayment.redirectToBankAccountLoginMethod)
 app.get('/tink/select-login-method', tinkPayment.selectLoginMethod)
 app.post('/tink/select-login-method', tinkPayment.makeBankPayment)
 app.get('/tink/callback', tinkPayment.handleReturn)
+app.get('/tink/qr-method', tinkPayment.makeBankPayment)
 
 // TrueLayer routes
 app.get('/truelayer/payment', truelayerPayment.showBankSelectorPage)

--- a/src/views/bank_account_login_method.njk
+++ b/src/views/bank_account_login_method.njk
@@ -5,6 +5,7 @@
         <h1 class="govuk-heading-l">How do you want to log in to your {{ displayName }} account?</h1>
         <form method="post">
             <input id="tinkRedirectUrl" name="tinkRedirectUrl" type="hidden" value="{{ tinkRedirectUrl }}">
+            <input id="qrCodeDataUrl" name="qrCodeDataUrl" type="hidden" value="{{ qrCodeDataUrl }}">
 
             {{ govukRadios({
               name: "loginMethod",

--- a/src/views/qr_method.njk
+++ b/src/views/qr_method.njk
@@ -1,0 +1,11 @@
+{% extends "layout.njk" %}
+
+{% block mainContent %}
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Scan this QR code on your mobile device to continue your payment.</h1>
+
+        <figure class="govuk-!-margin-top-0 govuk-!-margin-left-0 govuk-!-margin-bottom-6">
+          <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" data-cy="qr" alt="If you cannot view or scan the barcode, please enter the secret manually">
+        </figure>
+    </div>
+{% endblock %}

--- a/src/web/tink_payment.http.ts
+++ b/src/web/tink_payment.http.ts
@@ -33,7 +33,10 @@ export async function selectLoginMethod(req: Request, res: Response, next: NextF
 
 export async function makeBankPayment(req: Request, res: Response, next: NextFunction) {
     // TODO QR code method. Currently only works for same device.
-    res.redirect(req.body.tinkRedirectUrl)
+    if (req.body.loginMethod === 'device') {
+        return res.redirect(req.body.tinkRedirectUrl)
+    }
+    res.render('qr_method', { qrCodeDataUrl: req.body.qrCodeDataUrl })
 }
 
 export async function getTinkRedirectUrl(provider: string) {


### PR DESCRIPTION
 Show a QR code page if the user has selected to go down the QR code route. As
 far as prototyping is concerned, we're stopping at showing the QR code page. We
 don't feel we need to prototype refreshing the page as in reality this will
 work by polling a GOV.UK Pay status from the database.